### PR TITLE
Bugfix of `lastType` set to undefined

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -133,7 +133,7 @@ const plugin = ({ addFilter, utils }) => {
                                 {
                                     allTypes: acceptedFileTypesMapped_unique.join(', '),
                                     allButLastType: acceptedFileTypesMapped_unique.slice(0, -1).join(', '),
-                                    lastType: acceptedFileTypesMapped_unique[acceptedFileTypesMapped.length-1],
+                                    lastType: acceptedFileTypesMapped_unique[acceptedFileTypesMapped_unique.length-1],
                                 }
                             )
                         }


### PR DESCRIPTION
Bug generated from #45.
ATE, `undefined` was printed.

`file_validate_type_label_expected_types_map`
```json
[
  "video/mp4" : "mp4"
  "video/mp4v-es" : "mp4"
  "video/x-m4v" : "mp4"
  "video/quicktime" : "mov"
  "video/avi" : "avi"
  "video/divx" : "avi"
  "video/msvideo" : "avi"
  "video/vnd.divx" : "avi"
  "video/x-avi" : "avi"
  "video/x-msvideo" : "avi"
  "image/jpeg" : "jpg"
  "image/pjpeg" : "jpg"
  "image/png" : "png"
  "image/tiff" : "tiff"
  "text/plain" : "txt"
  "application/vnd.openxmlformats-officedocument.wordprocessingml.document" : "docx"
  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" : "xlsx"
  "application/pdf" : "pdf"
  "application/acrobat" : "pdf"
  "application/nappdf" : "pdf"
  "application/x-pdf" : "pdf"
  "image/pdf" : "pdf"
]
```

Result WITH bug:
![image](https://user-images.githubusercontent.com/25293190/218438867-b8ad70be-c404-4031-95cc-f8a24c18a508.png)

Result NOW:
![image](https://user-images.githubusercontent.com/25293190/218439132-e07f3bb7-5dea-4189-85fe-46daca72cf89.png)

